### PR TITLE
Installation fixes2016 10

### DIFF
--- a/v2/install.md
+++ b/v2/install.md
@@ -55,5 +55,8 @@ Run these commands in the root of your website:
 3. Enable Commerce (instructions below use [Drupal Console](https://drupalconsole.com))
 
  ```sh
- drupal module:install commerce_product commerce_checkout commerce_cart commerce_tax
+ cd web
+ drupal module:install commerce_product commerce_checkout commerce_cart
  ```
+ 
+ Depending on your exact environment you may have to/want to use ../vendor/bin/drupal instead of the unqualified drupal to get the site installed Drupal Console.

--- a/v2/install.md
+++ b/v2/install.md
@@ -53,6 +53,7 @@ Run these commands in the root of your website:
  This will also download the required libraries and modules (Address, Entity, State Machine, Inline Entity Form, Profile).
 
 3. Enable Commerce (instructions below use [Drupal Console](https://drupalconsole.com))
+ You must run this from the webroot rather than the site root. If you used the [Composer Template for Drupal Projects](https://github.com/drupal-composer/drupal-project) it will be `web`, if you've used a custom folder cd to that instead.
 
  ```sh
  cd web

--- a/v2/install.md
+++ b/v2/install.md
@@ -59,4 +59,4 @@ Run these commands in the root of your website:
  drupal module:install commerce_product commerce_checkout commerce_cart
  ```
  
- Depending on your exact environment you may have to/want to use ../vendor/bin/drupal instead of the unqualified drupal to get the site installed Drupal Console.
+ Depending on your exact environment you may have to/want to use `../vendor/bin/drupal` instead of the unqualified drupal to get the site installed Drupal Console.

--- a/v2/install.md
+++ b/v2/install.md
@@ -59,4 +59,4 @@ Run these commands in the root of your website:
  drupal module:install commerce_product commerce_checkout commerce_cart
  ```
  
- Depending on your exact environment you may have to/want to use `../vendor/bin/drupal` instead of the unqualified drupal to get the site installed Drupal Console.
+ Depending on your exact environment you may have to/want to use `../vendor/bin/drupal` instead of the unqualified `drupal` to use the site specific Drupal Console.


### PR DESCRIPTION
- currently no commerce_tax module so shouldn't attempt to install that.
- module:install has to be run from the web root rather than the site root.
- Note about using site specific Drupal Console.
