### PR TITLE
Note that receipt field accepts multiple addresses

### DIFF
--- a/user/pages/03.commerce2/01.user-guide/04.orders/04.customer-emails/docs.md
+++ b/user/pages/03.commerce2/01.user-guide/04.orders/04.customer-emails/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 ## Overview
 
-These settings are managed on an Order Type basis so that you can have different settings for different types of order and manage order notifications in a granular way.
+These settings are managed on an Order Type basis so that you can have different settings for different types of orders and manage order notifications in a granular way.
 
 
 ## Enable / Disable Customer Order Receipts & Store Notification Emails
@@ -24,4 +24,4 @@ Locate the **Emails** section
 ![Check / uncheck notification](commerce2-email-section.png)
 
  - Check / uncheck the **Email the customer a receipt when an order is placed** box.
- - Enter the store notification email address into the **Send a copy of the receipt to this email:** field.
+ - Enter the store notification email address into the **Send a copy of the receipt to this email:** field. You can enter multiple comma separated addresses into this field eg "one@example.com, two@example.com, three@example.com"


### PR DESCRIPTION
Not sure if that is the intention as a multi-value field would probably be better UX if multiples are intended.

Apparently 'types of orders' is better than 'types of order'. Maybe the singular is an NZ thing, or maybe it's just me? In any case the plural reads well to me.