### PR TITLE
Updated Commerce USPS module url

### DIFF
--- a/user/pages/03.commerce2/01.user-guide/09.shipping/docs.md
+++ b/user/pages/03.commerce2/01.user-guide/09.shipping/docs.md
@@ -14,6 +14,6 @@ provided by other module(s) for calculating actual shipping costs with shipping
 services. Currently available plugins with status as of December 24, 2017:
   - Flat Rate/Flate per Item - Beta, included in Commerce Shipping.
   - [Fedex](https://www.drupal.org/project/commerce_fedex) - Alpha.
-  - [USPS](https://www.drupal.org/project/commerce_usps) - In progress, not yet functional.
+  - [USPS](https://github.com/mattwebdev/commerce_usps) - In progress, not yet functional.
   - Other modules/plugins such as Canada Post, UPS, Kiala have yet to be ported
   or created for Drupal Commerce 2.x.


### PR DESCRIPTION
Previously URL for the module pointed to Drupal 7 version. Updated URL to point to Drupal 8 version of the module.