### PR TITLE
Fix the PHP Fatal error

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/05.payments/07.off-site-redirect-gateways/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/05.payments/07.off-site-redirect-gateways/docs.md
@@ -38,6 +38,7 @@ The class, in this case `RedirectCheckout`, must extend the `OffsitePaymentGatew
 namespace Drupal\commerce_quickpay\Plugin\Commerce\PaymentGateway;
 
 use Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\OffsitePaymentGatewayBase;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides the QuickPay offsite Checkout payment gateway.


### PR DESCRIPTION
```
PHP Fatal error:  Declaration of Drupal\commerce_quickpay\Plugin\Commerce\Pa
ymentGateway\RedirectCheckout::buildConfigurationForm(array $form, Drupal\easytransac\Plugin\Commerce\Paym
entGateway\FormStateInterface $form_state) must be compatible with Drupal\Core\Plugin\PluginFormInterface:
:buildConfigurationForm(array $form, Drupal\Core\Form\FormStateInterface $form_state) in /Applications/MAM
P/htdocs/web/modules/easytransac/src/Plugin/Commerce/PaymentGateway/RedirectCheckout.php on line 23
```