### PR TITLE
command to update was changed in drupal

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/02.install-update/03.updating/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/02.install-update/03.updating/docs.md
@@ -31,6 +31,6 @@ recommend running them on the command line rather than the
 `update.php` script. See the example below.
 
 ```bash
-drupal update:debug
+drupal debug:update
 drupal update:execute
 ```


### PR DESCRIPTION
[WARNING] Command "update:debug" was renamed, use "debug:update" instead.