### PR TITLE
Typo in Off-site (iFrame) payment gateways docs

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/05.payments/06.create-payment-gateway/03.off-site-gateways/02.off-site-iframe/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/05.payments/06.create-payment-gateway/03.off-site-gateways/02.off-site-iframe/docs.md
@@ -105,7 +105,7 @@ Once we've computed all the necessary *data* items, we'll attach them to the for
 $data = json_encode($data);
 
 $form['#attached']['library'][] = 'my_payment_gateway/iframe_file_name';
-$form['#attached']['drupalSettings']['my_custom_module'] $data;
+$form['#attached']['drupalSettings']['my_custom_module'] = $data;
 ```
 
 Your `buildConfigurationForm()` method should also build whatever form you want your customers to see. This may include form elements such as a message, submit button, and cancel button. If you are unfamiliar with building forms in Drupal 8, the [Drupal 8 Form API reference] may be helpful.


### PR DESCRIPTION
There is a missing equals sign in one of the code examples.

`$form['#attached']['drupalSettings']['my_custom_module'] $data;`