### PR TITLE
Update contributing doc for patches vs github

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/01.contributing/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/01.contributing/docs.md
@@ -7,7 +7,7 @@ taxonomy:
 
 ## Choosing an issue
 
-Commerce uses GitHub for code and drupal.org for tracking issues. To choose an
+Commerce uses patches for contributing code changes and drupal.org for tracking issues. To choose an
 issue, go through [the open issues], pick one you like and **assign it to you**.
 
 If you need help choosing an issue or working on one, join the Commerce 2.x office hours.
@@ -15,7 +15,11 @@ They are held every Wednesday at 5PM GMT+1 on the *#commerce* [Drupal Slack chan
 
 **Tip:** You can also view the issue queue as a [kanban board].
 
-## Creating a pull request
+## Setting up a local repository
+
+The Drupal Commerce [Version control page] includes instructions for setting up a local repository and keeping it up to date. See [Getting ready for development](setup-local-environment) for instructions on setting up a full local development environment.
+
+## Creating a patch
 
 Start by creating a branch for your work.
 The branch name should contain a brief summary of its id and the issue, e.g **2276369-fix-product-form-notice**:
@@ -25,50 +29,49 @@ cd web/modules/contrib/commerce
 git checkout -b 2276369-fix-product-form-notice
 ```
 
-Once you’re done with development, push your commits to your fork:
+Once you’re done with writing your code and you've committed all changes to your branch, use `diff` to create a patch. For example, if the current version of Drupal Commerce is `8.x-2.x`, create a patch like this:
 
 ```bash
-git commit -a -m "Issue 2276369: Fix notice in the product form."
-git push fork 2276369-fix-product-form-notice
+git diff 8.x-2.x > fix-product-form-notice-2276369-13.patch
 ```
 
-You can now go to your fork’s GitHub page and [create a pull request].
-Your pull request should link to the drupal.org issue, and vice-versa.
+Name your patch with this pattern: `[short-description]-[issue-number]-[comment-number].patch`
 
-After your code has been reviewed, you might be asked to perform some
-changes and then have them reviewed again:
+Note that the `[comment-number]` should be the number of the comment you *will post* to the issue; if the issue currently has 22 comments, then your comment number will be 23. If you have just created a new issue, then the comment number for your patch will be 2.
+
+## Creating an interdiff
+
+If your patch is not the initial patch for the issue, you should also create an interdiff. For an introduction to interdiffs and how to create them, see the Drupal.org documentation on [Creating an interdiff]. For example, you can use [patchutils] to create an interdiff for a new patch like this:
 
 ```bash
-# Change the desired files.
-git commit -a -m "Addressed feedback."
-git push fork 2276369-fix-product-form-notice
+interdiff fix-product-form-notice-2276369-7.patch fix-product-form-notice-2276369-13.patch > interdiff-2276369-7-13.txt
 ```
 
-Updating the branch will automatically update the related pull request.
+The naming convention for interdiff files is: `interdiff-[issue-number]-[comment-number-for-previous-patch]-[new-comment-number].txt`
 
-## Keeping up to date
+Using `.txt` as the extension ensures that the testbot will ignore your interdiff file.
 
-Your forked repository and the original one (called *origin*) will eventually get out of sync. Periodically update your fork by doing:
+## Update the issue and its status
 
-```bash
-# Update your local branch.
-git checkout 8.x-2.x
-git pull origin/8.x-2.x
-# Push the update to your GitHub fork.
-git push fork 8.x-2.x
-```
+Now that you've created the patch and interdiff locally, create a new comment on the issue and add your files. Typically, your patch will get automatically queued for testing. If not, you can click the `Add test / retest` link that appears below your uploaded patch to trigger the testbot.
 
-Your pull request might also need rebasing, to re-apply your changes on top of the latest code. Once you’ve updated the master branch (8.x-2.x), rebase your branch:
+If there are any test failures, you should leave the issue status set to "Needs work" until the problems are resolved. If all tests pass, update the issue status to "Needs review" to get feedback from other members of the community and reviews by the module maintainers.
 
-```bash
-git checkout 2276369-fix-product-form-notice
-git rebase 8.x-2.x
-git push -f fork 2276369-fix-product-form-notice
-```
+Do *not* set the status to "Fixed" even though you've provided a "fix" in the form of your patch. The Fixed status is used by the module maintainers to indicate that either the latest patch has been committed to the development repository or the question asked in the issue has been sufficiently answered in the comments.
+
+Typically, an issue will need several cycles of reviews and revisions before it is ready to be committed to the Drupal Commerce project.
+
+## Reviewing patches
+
+Reviewing patches created by other members of the community is another valuable way to contribute to Drupal Commerce. See the [Patching documentation](../install-update/patching) for information on how to apply an issue patch.
+
+Once you've tested a patch, leave a comment on the issue. If the patch worked for you, you can change the issue status to "Reviewed & tested by the community". If the patch didn't work for you, you can change the issue status to "Needs work". Provide as many details as possible to help developers reproduce your results and figure out how to fix the patch.
 
 That’s it! Happy contributing!
 
 [the open issues]: https://www.drupal.org/project/issues/search/commerce?assigned=&submitted=&project_issue_followers=&status%5B0%5D=Open&version%5B0%5D=8.x&issue_tags_op=%3D&issue_tags=&text=&&&&order=field_issue_priority&sort=desc
 [Drupal Slack channel]: https://www.drupal.org/slack
 [kanban board]: https://contribkanban.com/board/commerce2x
-[create a pull request]: https://help.github.com/articles/using-pull-requests#initiating-the-pull-request
+[Version control page]: https://www.drupal.org/project/commerce/git-instructions
+[Creating an interdiff]: https://www.drupal.org/documentation/git/interdiff
+[patchutils]: http://freshmeat.sourceforge.net/projects/patchutils


### PR DESCRIPTION
Remove the part that tells people to send github PRs, patches are fine now.