### PR TITLE
Remove preceding slash

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/08.checkout/02.create-custom-checkout-pane/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/08.checkout/02.create-custom-checkout-pane/docs.md
@@ -18,7 +18,7 @@ execute this command from docroot:
 drupal generate:module  \
   --module="My checkout pane" \
   --machine-name="my_checkout_pane" \
-  --module-path="/modules/custom" \
+  --module-path="modules/custom" \
   --description="My checkout pane" \
   --core="8.x" \
   --package="Custom" \


### PR DESCRIPTION
An absolute file ref causes an invalid path error when running the `drupal` command.  The path is relative to the drupal root.