### PR TITLE
Remove dependencies specification

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/08.checkout/02.create-custom-checkout-pane/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/08.checkout/02.create-custom-checkout-pane/docs.md
@@ -22,8 +22,7 @@ drupal generate:module  \
   --description="My checkout pane" \
   --core="8.x" \
   --package="Custom" \
-  --composer \
-  --dependencies="commerce:commerce_checkout"
+  --composer
 ```
 
 Now create the plugin using this command:


### PR DESCRIPTION
Drupal console `generate:module` cannot handle submodule dependencies.  The command generates an error as originally written.  Ref: https://github.com/hechoendrupal/drupal-console/issues/2541