### PR TITLE
Command "update:debug" was renamed

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/02.install-update/03.updating/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/02.install-update/03.updating/docs.md
@@ -30,7 +30,7 @@ recommend running them on the command line rather than the
 `update.php` script. See the example below.
 
 ```bash
-drupal update:debug
+drupal debug:update
 drupal update:execute
 ```
 


### PR DESCRIPTION
If you run `drupal update:debug` you get this message `[WARNING] Command "update:debug" was renamed, use "debug:update" instead.`