### PR TITLE
Make update command (wildcard) work on zsh

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/02.install-update/03.updating/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/02.install-update/03.updating/docs.md
@@ -13,7 +13,7 @@ Due to the way Drupal.org manages package information, you need to run one of th
 To update Drupal Commerce and all contributed projects extending Drupal Commerce:
 
 ```bash
-composer update --with-dependencies drupal/commerce*
+composer update --with-dependencies "drupal/commerce*"
 ```
 
 If you want to *only* upgrade Drupal Commerce, run this command:


### PR DESCRIPTION
zsh fails if there are no double or single qoutes added with the error:
```
zsh: no matches found: drupal/commerce*
```