### PR TITLE
Fix ePayco payment module url, currencies and countries

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/05.payments/01.available-gateways/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/05.payments/01.available-gateways/docs.md
@@ -295,8 +295,8 @@ If you create your own payment gateway module or find one that's not in this lis
 | --- | --- |
 | **Description** | ePayco is a Colombian payment gateway that Integrate ePayco Off-site payments, Set-up global gateway settings, Alter payment data dinamically 
 | **Type** | Off site |
-| **Currencies** | Bulgaria |
-| **Countries** | BGN |
+| **Currencies** | COP, USD |
+| **Countries** | Colombia |
 [/ui-accordion-item]
 [ui-accordion-item title="eProcessing Network (EPN)"]
 |  | [eProcessing Network (EPN)] |

--- a/user/pages/03.commerce2/02.developer-guide/05.payments/01.available-gateways/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/05.payments/01.available-gateways/docs.md
@@ -1077,7 +1077,7 @@ If you create your own payment gateway module or find one that's not in this lis
 [DIBS integration]: https://www.drupal.org/project/commerce_dibs
 [DPS]: https://www.drupal.org/project/commerce_dps
 [Elavon]: https://www.drupal.org/project/commerce_elavon
-[ePayco]: https://www.drupal.org/project/commerce_epayco
+[ePayco]: https://www.drupal.org/project/epayco
 [GoCardless]: https://www.drupal.org/project/commerce_gocardless
 [Liqpay Gateway]: https://www.drupal.org/project/commerce_liqpay_gateway
 [MultiSafepay]: https://www.drupal.org/project/commerce_multisafepay


### PR DESCRIPTION
The ePayco module [commerce_epayco](https://www.drupal.org/project/commerce_epayco) has been replaced by the module [epayco](https://www.drupal.org/project/epayco) so the url has been updated.

According to the official ePayco documentation, only COP and USD currencies are supported; also only Colombia is the supported country: https://docs.epayco.co/payments/checkout