### PR TITLE
Fix link to commerce 2 entity relationship blog

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/03.core/05.relationships/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/03.core/05.relationships/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 Drupal Commerce has many models and relationships. This page provides explainations as to how these different models related, including entity relationship diagrams.
 
-[Full ERD: https://www.dx-experts.nl/commerce-2-entity-relations-including-shipping](https://www.dx-experts.nl/commerce-2-entity-relations-including-shipping)
+[Full ERD: https://www.dx-experts.nl/blog/2017/commerce-2-entity-relations-including-shipping/](https://www.dx-experts.nl/blog/2017/commerce-2-entity-relations-including-shipping/)
 
 ![Store Entity Diagram. Stores are M:M for products and M:1 for Orders.](store-entity-diagram.png)
 


### PR DESCRIPTION
The current URL gives a 404 page. This new one is called "Commerce 2 entity relations - including Shipping" at https://www.dx-experts.nl/blog/, so I'm guessing it's the same page, just moved.