### PR TITLE
Fix email body and module name

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/07.orders/04.workflows/05.react-to-workflow-transitions/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/07.orders/04.workflows/05.react-to-workflow-transitions/docs.md
@@ -83,10 +83,10 @@ Here is an example that you can modify according to your requirements.
             'Regarding your order [#@number]',
             ['@number' => $order->getOrderNumber()]
           ),
-          'body' => $this->t(
+          'body' => ['#markup' => $this->t(
             'Your order with #@number that you have placed with us has been processed and is awaiting fulfillment.',
             ['@number' => $order->getOrderNumber()]
-          ),
+          )],
         ];
 
         // Set the language that will be used in translations.
@@ -98,7 +98,7 @@ Here is an example that you can modify according to your requirements.
         }
 
         // Send the email.
-        $this->mailManager->mail('commerce_order', 'receipt', $to, $langcode, $params);
+        $this->mailManager->mail('commerce', 'receipt', $to, $langcode, $params);
       }
 
     }


### PR DESCRIPTION
WSOD because the body is not passed properly to the render array.
hook_mail() is implemented on the commerce module, not the commerce_order module. If this is not set to commerce or the custom module's own hook_mail() implementation then an empty email is sent.