### PR TITLE
Changing bcmatch to bcmath

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/02.install-update/01.requirements/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/02.install-update/01.requirements/docs.md
@@ -27,7 +27,7 @@ taxonomy:
  php_packages_extra:
    - php7.1-bcmath
  ```
- - If you are having issues related to the bcmatch extension, the [Drupal VM documentation] provides useful information.
+ - If you are having issues related to the bcmath extension, the [Drupal VM documentation] provides useful information.
 
 ### Links and resources
 * [Best Practice Drupal Development](https://drupalize.me/tutorial/best-practice-drupal-development)


### PR DESCRIPTION
In the line just above "Links and resources," bcmatch is mentioned. This changes it to bcmath, which is what the document has been referring to up to that point.