### PR TITLE
Adding installation to module creation

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/03.core/00.libraries-and-dependencies/03.state-machine/02.state-fields/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/03.core/00.libraries-and-dependencies/03.state-machine/02.state-fields/docs.md
@@ -18,7 +18,7 @@ All that is fairly straightforward, but we have a problem. We cannot set a "Work
 
 ![Configure state field workgroup](../images/custom-state-fields-2.png)
 
-It is not possible to create a workflow through the admin UI, so we need to add its definition using a custom module. See the Drupal.org [Creating custom modules] documentation if you need help getting started. In this example, we'll assume we've created a custom module named `mymodule`.
+It is not possible to create a workflow through the admin UI, so we need to add its definition using a custom module. See the Drupal.org [Creating custom modules] documentation if you need help getting started. In this example, we'll assume we've created and installed a custom module named `mymodule`.
 
 We need to create both a custom workflow and a workflow group for our order item State field. [Workflow] and [WorkflowGroup] are plugins defined in YAML, similar to [menu links].
 


### PR DESCRIPTION
Adding "and installed" to the sentence about creating a custom module, so that when the reader gets to the part about clearing their caches, there isn't a disconnect. Technically, this shouldn't be necessary, but it is helpful.