### PR TITLE
Add Single media module to Product images page

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/03.products/04.displaying-products/06.product-images/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/03.products/04.displaying-products/06.product-images/docs.md
@@ -58,6 +58,8 @@ See the [Multi-product displays documentation](../05.multiple-products) for an e
 
 The *Single image* view mode will now be an option for displaying product variations.
 
+#### Single media
+The [Single media](https://www.drupal.org/project/single_media) is very similar to previous one, but provides field formatter for **media** fields that are configured for multiple images.
 
 ### Links and resources
 * Drupal 8 User Guide documentation on [Concept: Image Styles]


### PR DESCRIPTION
There is only one module in the documentation (image delta formatter) that allows you to capture an image by delta and view mode, but this module only works with the image field, I suggest adding another one that allows you to select media by delta (https://www.drupal.org/project/single_media).