### PR TITLE
Update installation docs.md

### DIFF
--- a/user/pages/03.commerce2/02.developer-guide/02.install-update/02.installation/docs.md
+++ b/user/pages/03.commerce2/02.developer-guide/02.install-update/02.installation/docs.md
@@ -45,10 +45,10 @@ Be sure to [review requirements](../01.requirements) before starting the install
 
  #### Enable Commerce
 
- The instructions below use [Drupal Console]
+ The instructions below use [Drush](https://www.drush.org)
 
  ```bash
- drupal module:install commerce_product commerce_checkout commerce_cart
+ drush pm:install commerce_product commerce_checkout commerce_cart
  ```
 
 ## Alternative installation instructions for Ludwig users


### PR DESCRIPTION
Switch docs to show drush command. Console is not installable on PHP 8.1/D10:
https://github.com/hechoendrupal/drupal-console/issues/4344